### PR TITLE
chore: upgrade target to go 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vincentfiestada/octostats
 
-go 1.15
+go 1.16
 
 require (
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b


### PR DESCRIPTION
Upgrade target Go version to [1.16](https://golang.org/doc/go1.16)